### PR TITLE
Update multicast-dns to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
   },
   "dependencies": {
     "ipfs-logger": "^0.1.0",
-    "peer-info": "^0.3.2",
-    "peer-id": "^0.3.3",
+    "mdns-txt": "^2.0.0",
     "multiaddr": "^1.0.0",
-    "multicast-dns": "^3.0.0"
+    "multicast-dns": "^3.0.0",
+    "peer-id": "^0.3.3",
+    "peer-info": "^0.3.2"
   }
 }


### PR DESCRIPTION
- [ ] use mdns-txt
- [ ] make sure mdns in go is compliant with https://tools.ietf.org/html/rfc6763
- [ ] integration tests for go and js? (fun!)

more context: https://github.com/mafintosh/multicast-dns/pull/24#issuecomment-166851603
