### PR TITLE
Service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ mdns.start(() => setTimeout(() => mdns.stop(() => {}), 20 * 1000))
 ```
 
 - options
-  - `broadcast` - (true/false) announce our presence through mDNS
-  - `interval` - query interval
-  - `serviceTag` - name of the service announced
+  - `broadcast` - (true/false) announce our presence through mDNS, default false
+  - `interval` - query interval, default 10 * 1000 (10 seconds)
+  - `serviceTag` - name of the service announcedm, default 'ipfs.local`

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ class MulticastDNS extends EventEmitter {
 
     this.broadcast = options.broadcast !== false
     this.interval = options.interval || (1e3 * 10)
-    this.serviceTag = options.serviceTag || '_ipfs-discovery._udp'
+    this.serviceTag = options.serviceTag || 'ipfs.local'
     this.port = options.port || 5353
     this.peerInfo = peerInfo
     this._queryInterval = null

--- a/src/query.js
+++ b/src/query.js
@@ -55,8 +55,9 @@ module.exports = {
     answers.a.forEach((a) => {
       multiaddrs.push(new Multiaddr('/ip4/' + a.data + '/tcp/' + port))
     })
-
-    // TODO Create multiaddrs from AAAA (IPv6) records as well
+    answers.aaaa.forEach((a) => {
+      multiaddrs.push(new Multiaddr('/ip6/' + a.data + '/tcp/' + port))
+    })
 
     if (peerInfo.id.toB58String() === b58Id) {
       return // replied to myself, ignore

--- a/src/query.js
+++ b/src/query.js
@@ -12,7 +12,7 @@ const tcp = new TCP()
 module.exports = {
 
   queryLAN: function (mdns, serviceTag, interval) {
-    return setInterval(() => {
+    const query = () => {
       log('query', serviceTag)
       mdns.query({
         questions: [{
@@ -20,7 +20,11 @@ module.exports = {
           type: 'PTR'
         }]
       })
-    }, interval)
+    }
+
+    // Immediately start a query, then do it every interval.
+    query()
+    return setInterval(query, interval)
   },
 
   gotResponse: function (rsp, peerInfo, serviceTag, callback) {

--- a/src/query.js
+++ b/src/query.js
@@ -13,6 +13,7 @@ module.exports = {
 
   queryLAN: function (mdns, serviceTag, interval) {
     return setInterval(() => {
+      log('query', serviceTag)
       mdns.query({
         questions: [{
           name: serviceTag,
@@ -142,6 +143,7 @@ module.exports = {
         }
       })
 
+      log('responding to query')
       mdns.respond(answers)
     }
   }

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -139,7 +139,7 @@ describe('MulticastDNS', () => {
     ], () => {
       mdnsA.once('peer', (peerInfo) => {
         expect(pB.id.toB58String()).to.eql(peerInfo.id.toB58String())
-        expect(peerInfo.multiaddrs.size).to.equal(2);
+        expect(peerInfo.multiaddrs.size).to.equal(2)
         parallel([
           (cb) => mdnsA.stop(cb),
           (cb) => mdnsB.stop(cb)

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -8,6 +8,7 @@ chai.use(dirtyChai)
 const multiaddr = require('multiaddr')
 const PeerInfo = require('peer-info')
 const parallel = require('async/parallel')
+const series = require('async/series')
 
 const MulticastDNS = require('./../src')
 
@@ -133,9 +134,9 @@ describe('MulticastDNS', () => {
     })
     const mdnsB = new MulticastDNS(pB, options)
 
-    parallel([
-      (cb) => mdnsA.start(cb),
-      (cb) => mdnsB.start(cb)
+    series([
+      (cb) => mdnsB.start(cb),
+      (cb) => mdnsA.start(cb)
     ], () => {
       mdnsA.once('peer', (peerInfo) => {
         expect(pB.id.toB58String()).to.eql(peerInfo.id.toB58String())
@@ -150,12 +151,7 @@ describe('MulticastDNS', () => {
     })
   })
 
-  /*
-   * This test is WRONG.  Peers are async.  How can you assume
-   * that the mdnsA.stop happens before mdnsC gets a response
-   * from mdnsA?
-   */
-  it.skip('doesn\'t emit peers after stop', function (done) {
+  it('doesn\'t emit peers after stop', function (done) {
     this.timeout(40 * 1000)
 
     const options = {
@@ -164,18 +160,13 @@ describe('MulticastDNS', () => {
     const mdnsA = new MulticastDNS(pA, options)
     const mdnsC = new MulticastDNS(pC, options)
 
-    setTimeout(done, 15000)
-
-    parallel([
+    series([
       (cb) => mdnsA.start(cb),
+      (cb) => setTimeout(cb, 1000),
+      (cb) => mdnsA.stop(cb),
       (cb) => mdnsC.start(cb)
     ], () => {
-      mdnsA.stop((err) => {
-        if (err) {
-          return done(err)
-        }
-      })
-
+      setTimeout(() => mdnsC.stop(done), 5000)
       mdnsC.once('peer', (peerInfo) => {
         done(new Error('Should not receive new peer.'))
       })

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -18,7 +18,7 @@ describe('MulticastDNS', () => {
   let pD
 
   before(function (done) {
-    this.timeout(40 * 1000)
+    this.timeout(80 * 1000)
     parallel([
       (cb) => {
         PeerInfo.create((err, peer) => {


### PR DESCRIPTION
- All services must be in the '.local' domain (see https://github.com/libp2p/js-libp2p-mdns/issues/67)
- Change the service name from `_ipfs-discovery._udp` to `ipfs`
- IPv6 support (see #1)
- Don't wait interval for a query to begin (see https://github.com/libp2p/go-libp2p/issues/256)