### PR TITLE
Use latest multicast-dns and dns-packet

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "libp2p-tcp": "~0.11.2",
     "multiaddr": "^3.0.2",
-    "multicast-dns": "^6.2.3",
+    "multicast-dns": "git+https://github.com/richardschneider/multicast-dns.git#dns-packet",
     "peer-id": "~0.10.5",
     "peer-info": "~0.11.6"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "libp2p-tcp": "~0.11.2",
     "multiaddr": "^3.0.2",
-    "multicast-dns": "git+https://github.com/richardschneider/multicast-dns.git#dns-packet",
+    "multicast-dns": "^7.0.0",
     "peer-id": "~0.10.5",
     "peer-info": "~0.11.6"
   },

--- a/src/query.js
+++ b/src/query.js
@@ -53,7 +53,7 @@ module.exports = {
       return
     }
 
-    const b58Id = answers.txt.data.toString()
+    const b58Id = answers.txt.data[0].toString()
     const port = answers.srv.data.port
     const multiaddrs = []
 
@@ -96,7 +96,7 @@ module.exports = {
       answers.push({
         name: serviceTag,
         type: 'PTR',
-        class: 1,
+        class: 'IN',
         ttl: 120,
         data: peerInfo.id.toB58String() + '.' + serviceTag
       })
@@ -107,7 +107,7 @@ module.exports = {
       answers.push({
         name: peerInfo.id.toB58String() + '.' + serviceTag,
         type: 'SRV',
-        class: 1,
+        class: 'IN',
         ttl: 120,
         data: {
           priority: 10,
@@ -120,7 +120,7 @@ module.exports = {
       answers.push({
         name: peerInfo.id.toB58String() + '.' + serviceTag,
         type: 'TXT',
-        class: 1,
+        class: 'IN',
         ttl: 120,
         data: peerInfo.id.toB58String()
       })
@@ -130,7 +130,7 @@ module.exports = {
           answers.push({
             name: os.hostname(),
             type: 'A',
-            class: 1,
+            class: 'IN',
             ttl: 120,
             data: ma.toString().split('/')[2]
           })
@@ -140,7 +140,7 @@ module.exports = {
           answers.push({
             name: os.hostname(),
             type: 'AAAA',
-            class: 1,
+            class: 'IN',
             ttl: 120,
             data: ma.toString().split('/')[2]
           })


### PR DESCRIPTION
This is needed for issue #65

I've created a repo that has the latest `dns-packet` and `multicast-dns` bits.  Until, they are both released to NPM, we can use it to solve our problems.