### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ libp2p-mdns JavaScript implementation
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-mdns.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-mdns)
 [![](https://img.shields.io/travis/libp2p/js-libp2p-mdns.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-mdns)
 [![Dependency Status](https://david-dm.org/libp2p/js-libp2p-mdns.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-mdns)

--- a/package.json
+++ b/package.json
@@ -34,18 +34,18 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mdns",
   "devDependencies": {
-    "aegir": "^18.0.2",
-    "async": "^2.6.1",
+    "aegir": "^18.2.2",
+    "async": "^2.6.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1"
   },
   "dependencies": {
     "debug": "^4.1.1",
     "libp2p-tcp": "~0.13.0",
-    "multiaddr": "^6.0.2",
+    "multiaddr": "^6.0.6",
     "multicast-dns": "^7.2.0",
-    "peer-id": "~0.12.0",
-    "peer-info": "~0.15.0"
+    "peer-id": "~0.12.2",
+    "peer-info": "~0.15.1"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated