### PR TITLE
fix: do not emit empty peer info objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,10 @@ class MulticastDNS extends EventEmitter {
   async _onMdnsResponse (event) {
     try {
       const foundPeer = await query.gotResponse(event, this.peerInfo, this.serviceTag)
-      this.emit('peer', foundPeer)
+
+      if (foundPeer) {
+        this.emit('peer', foundPeer)
+      }
     } catch (err) {
       log('Error processing peer response', err)
     }


### PR DESCRIPTION
I noticed stack traces in the logs from trying to access properties of `undefined`. It seems this module emits `undefined` `peerInfo` values, for example when recieving a response to your own mDNS query or a response with an invalid PeerID.

This PR guards on empty PeerInfo objects from `query.gotResponse`