### PR TITLE
fix: remove use of assert module

### DIFF
--- a/src/compat/querier.js
+++ b/src/compat/querier.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assert = require('assert')
 const EE = require('events')
 const MDNS = require('multicast-dns')
 const Multiaddr = require('multiaddr')
@@ -14,7 +13,9 @@ const { SERVICE_TAG_LOCAL, MULTICAST_IP, MULTICAST_PORT } = require('./constants
 class Querier extends EE {
   constructor (peerId, options) {
     super()
-    assert(peerId, 'missing peerId parameter')
+    if (!peerId) {
+      throw new Error('missing peerId parameter')
+    }
     options = options || {}
     this._peerIdStr = peerId.toB58String()
     // Re-query every 60s, in leu of network change detection

--- a/src/compat/responder.js
+++ b/src/compat/responder.js
@@ -1,14 +1,16 @@
 'use strict'
 
 const OS = require('os')
-const assert = require('assert')
 const MDNS = require('multicast-dns')
 const log = require('debug')('libp2p:mdns:compat:responder')
 const { SERVICE_TAG_LOCAL } = require('./constants')
 
 class Responder {
   constructor (peerInfo) {
-    assert(peerInfo, 'missing peerInfo parameter')
+    if (!peerInfo) {
+      throw new Error('missing peerInfo parameter')
+    }
+
     this._peerInfo = peerInfo
     this._peerIdStr = peerInfo.id.toB58String()
     this._onQuery = this._onQuery.bind(this)

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 const multicastDNS = require('multicast-dns')
 const EventEmitter = require('events').EventEmitter
-const assert = require('assert')
 const debug = require('debug')
 const log = debug('libp2p:mdns')
 const query = require('./query')
@@ -11,7 +10,9 @@ const GoMulticastDNS = require('./compat')
 class MulticastDNS extends EventEmitter {
   constructor (options = {}) {
     super()
-    assert(options.peerInfo, 'needs a PeerInfo to work')
+    if (!options.peerInfo) {
+      throw new Error('needs a PeerInfo to work')
+    }
 
     this.broadcast = options.broadcast !== false
     this.interval = options.interval || (1e3 * 10)


### PR DESCRIPTION
The polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.