### PR TITLE
chore: peer-discovery not using peer-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ const MDNS = require('libp2p-mdns')
 
 const mdns = new MDNS(options)
 
-mdns.on('peer', (peerInfo) => {
-  console.log('Found a peer in the local network', peerInfo.id.toB58String())
+mdns.on('peer', (peerData) => {
+  console.log('Found a peer in the local network', peerData.id.toB58String(), peerData.multiaddrs)
 })
 
 // Broadcast for 20 seconds
@@ -33,7 +33,8 @@ setTimeout(() => mdns.stop(), 20 * 1000)
 ```
 
 - options
-  - `peerInfo` - PeerInfo to announce
+  - `peerId` - PeerId to announce
+  - `multiaddrs` - multiaddrs to announce
   - `broadcast` - (true/false) announce our presence through mDNS, default `false`
   - `interval` - query interval, default 10 * 1000 (10 seconds)
   - `serviceTag` - name of the service announce , default 'ipfs.local`

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "debug": "^4.1.1",
     "multiaddr": "^7.1.0",
     "multicast-dns": "^7.2.0",
-    "peer-id": "~0.13.3",
-    "peer-info": "~0.17.0"
+    "peer-id": "~0.13.3"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "^4.2.0",
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x",
+    "libp2p-interfaces": "^0.3.0",
     "p-defer": "^3.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "^4.2.0",
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
-    "interface-discovery": "^0.1.1",
+    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x",
     "p-defer": "^3.0.0"
   },
   "dependencies": {

--- a/src/compat/index.js
+++ b/src/compat/index.js
@@ -7,11 +7,13 @@ const Responder = require('./responder')
 const Querier = require('./querier')
 
 class GoMulticastDNS extends EE {
-  constructor (peerId, multiaddrs) {
+  constructor ({ peerId, multiaddrs, queryPeriod, queryInterval }) {
     super()
     this._started = false
     this._peerId = peerId
     this._multiaddrs = multiaddrs
+    this._queryPeriod = queryPeriod
+    this._queryInterval = queryInterval
     this._onPeer = this._onPeer.bind(this)
   }
 
@@ -21,8 +23,15 @@ class GoMulticastDNS extends EE {
     }
 
     this._started = true
-    this._responder = new Responder(this._peerId, this._multiaddrs)
-    this._querier = new Querier(this._peerId)
+    this._responder = new Responder({
+      peerId: this._peerId,
+      multiaddrs: this._multiaddrs
+    })
+    this._querier = new Querier({
+      peerId: this._peerId,
+      queryInterval: this._queryInterval,
+      queryPeriod: this._queryPeriod
+    })
 
     this._querier.on('peer', this._onPeer)
 
@@ -32,8 +41,8 @@ class GoMulticastDNS extends EE {
     ])
   }
 
-  _onPeer (peerInfo) {
-    this.emit('peer', peerInfo)
+  _onPeer (peerData) {
+    this.emit('peer', peerData)
   }
 
   stop () {

--- a/src/compat/index.js
+++ b/src/compat/index.js
@@ -7,10 +7,11 @@ const Responder = require('./responder')
 const Querier = require('./querier')
 
 class GoMulticastDNS extends EE {
-  constructor (peerInfo) {
+  constructor (peerId, multiaddrs) {
     super()
     this._started = false
-    this._peerInfo = peerInfo
+    this._peerId = peerId
+    this._multiaddrs = multiaddrs
     this._onPeer = this._onPeer.bind(this)
   }
 
@@ -20,8 +21,8 @@ class GoMulticastDNS extends EE {
     }
 
     this._started = true
-    this._responder = new Responder(this._peerInfo)
-    this._querier = new Querier(this._peerInfo.id)
+    this._responder = new Responder(this._peerId, this._multiaddrs)
+    this._querier = new Querier(this._peerId)
 
     this._querier.on('peer', this._onPeer)
 

--- a/src/compat/querier.js
+++ b/src/compat/querier.js
@@ -10,24 +10,24 @@ log.error = debug('libp2p:mdns:compat:querier:error')
 const { SERVICE_TAG_LOCAL, MULTICAST_IP, MULTICAST_PORT } = require('./constants')
 
 class Querier extends EE {
-  constructor (peerId, options) {
+  constructor ({ peerId, queryInterval = 60000, queryPeriod }) {
     super()
 
     if (!peerId) {
       throw new Error('missing peerId parameter')
     }
 
-    options = options || {}
     this._peerIdStr = peerId.toB58String()
-    // Re-query every 60s, in leu of network change detection
-    options.queryInterval = options.queryInterval || 60000
-    // Time for which the MDNS server will stay alive waiting for responses
-    // Must be less than options.queryInterval!
-    options.queryPeriod = Math.min(
-      options.queryInterval,
-      options.queryPeriod == null ? 5000 : options.queryPeriod
-    )
-    this._options = options
+    this._options = {
+      // Re-query in leu of network change detection (every 60s by default)
+      queryInterval: queryInterval,
+      // Time for which the MDNS server will stay alive waiting for responses
+      // Must be less than options.queryInterval!
+      queryPeriod: Math.min(
+        queryInterval,
+        queryPeriod == null ? 5000 : queryPeriod
+      )
+    }
     this._onResponse = this._onResponse.bind(this)
   }
 

--- a/src/compat/responder.js
+++ b/src/compat/responder.js
@@ -6,13 +6,14 @@ const log = require('debug')('libp2p:mdns:compat:responder')
 const { SERVICE_TAG_LOCAL } = require('./constants')
 
 class Responder {
-  constructor (peerInfo) {
-    if (!peerInfo) {
-      throw new Error('missing peerInfo parameter')
+  constructor (peerId, multiaddrs) {
+    if (!peerId) {
+      throw new Error('missing peerId parameter')
     }
 
-    this._peerInfo = peerInfo
-    this._peerIdStr = peerInfo.id.toB58String()
+    this._peerId = peerId
+    this._peerIdStr = peerId.toB58String()
+    this._multiaddrs = multiaddrs
     this._onQuery = this._onQuery.bind(this)
   }
 
@@ -22,7 +23,7 @@ class Responder {
   }
 
   _onQuery (event, info) {
-    const addresses = this._peerInfo.multiaddrs.toArray().map(ma => ma.toOptions())
+    const addresses = this._multiaddrs.map(ma => ma.toOptions())
     // Only announce TCP for now
     if (!addresses.length) return
 

--- a/src/compat/responder.js
+++ b/src/compat/responder.js
@@ -6,7 +6,7 @@ const log = require('debug')('libp2p:mdns:compat:responder')
 const { SERVICE_TAG_LOCAL } = require('./constants')
 
 class Responder {
-  constructor (peerId, multiaddrs) {
+  constructor ({ peerId, multiaddrs }) {
     if (!peerId) {
       throw new Error('missing peerId parameter')
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const multicastDNS = require('multicast-dns')
-const EventEmitter = require('events').EventEmitter
+const { EventEmitter } = require('events')
 const debug = require('debug')
 const log = debug('libp2p:mdns')
 const query = require('./query')
@@ -10,20 +10,22 @@ const GoMulticastDNS = require('./compat')
 class MulticastDNS extends EventEmitter {
   constructor (options = {}) {
     super()
-    if (!options.peerInfo) {
-      throw new Error('needs a PeerInfo to work')
+
+    if (!options.peerId) {
+      throw new Error('needs own PeerId to work')
     }
 
     this.broadcast = options.broadcast !== false
     this.interval = options.interval || (1e3 * 10)
     this.serviceTag = options.serviceTag || 'ipfs.local'
     this.port = options.port || 5353
-    this.peerInfo = options.peerInfo
+    this.peerId = options.peerId
+    this.peerMultiaddrs = options.multiaddrs || []
     this._queryInterval = null
     this._onPeer = this._onPeer.bind(this)
 
     if (options.compat !== false) {
-      this._goMdns = new GoMulticastDNS(options.peerInfo, {
+      this._goMdns = new GoMulticastDNS(options.peerId, this.peerMultiaddrs, {
         queryPeriod: options.compatQueryPeriod,
         queryInterval: options.compatQueryInterval
       })
@@ -51,12 +53,12 @@ class MulticastDNS extends EventEmitter {
   }
 
   _onMdnsQuery (event) {
-    query.gotQuery(event, this.mdns, this.peerInfo, this.serviceTag, this.broadcast)
+    query.gotQuery(event, this.mdns, this.peerId, this.peerMultiaddrs, this.serviceTag, this.broadcast)
   }
 
   async _onMdnsResponse (event) {
     try {
-      const foundPeer = await query.gotResponse(event, this.peerInfo, this.serviceTag)
+      const foundPeer = await query.gotResponse(event, this.peerId, this.serviceTag)
 
       if (foundPeer) {
         this.emit('peer', foundPeer)

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,9 @@ class MulticastDNS extends EventEmitter {
     this._onPeer = this._onPeer.bind(this)
 
     if (options.compat !== false) {
-      this._goMdns = new GoMulticastDNS(options.peerId, this.peerMultiaddrs, {
+      this._goMdns = new GoMulticastDNS({
+        multiaddrs: this.peerMultiaddrs,
+        peerId: options.peerId,
         queryPeriod: options.compatQueryPeriod,
         queryInterval: options.compatQueryInterval
       })
@@ -56,9 +58,9 @@ class MulticastDNS extends EventEmitter {
     query.gotQuery(event, this.mdns, this.peerId, this.peerMultiaddrs, this.serviceTag, this.broadcast)
   }
 
-  async _onMdnsResponse (event) {
+  _onMdnsResponse (event) {
     try {
-      const foundPeer = await query.gotResponse(event, this.peerId, this.serviceTag)
+      const foundPeer = query.gotResponse(event, this.peerId, this.serviceTag)
 
       if (foundPeer) {
         this.emit('peer', foundPeer)
@@ -68,8 +70,8 @@ class MulticastDNS extends EventEmitter {
     }
   }
 
-  _onPeer (peerInfo) {
-    this.emit('peer', peerInfo)
+  _onPeer (peerData) {
+    this.emit('peer', peerData)
   }
 
   /**

--- a/test/compat/go-multicast-dns.spec.js
+++ b/test/compat/go-multicast-dns.spec.js
@@ -27,14 +27,20 @@ describe('GoMulticastDNS', () => {
   })
 
   it('should start and stop', async () => {
-    const mdns = new GoMulticastDNS(peerIds[0], [peerAddrs[0]])
+    const mdns = new GoMulticastDNS({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
 
     await mdns.start()
     return mdns.stop()
   })
 
   it('should ignore multiple start calls', async () => {
-    const mdns = new GoMulticastDNS(peerIds[0], [peerAddrs[0]])
+    const mdns = new GoMulticastDNS({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
 
     await mdns.start()
     await mdns.start()
@@ -43,13 +49,22 @@ describe('GoMulticastDNS', () => {
   })
 
   it('should ignore unnecessary stop calls', async () => {
-    const mdns = new GoMulticastDNS(peerIds[0], [peerAddrs[0]])
+    const mdns = new GoMulticastDNS({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
     await mdns.stop()
   })
 
-  it('should emit peer info when peer is discovered', async () => {
-    const mdnsA = new GoMulticastDNS(peerIds[0], [peerAddrs[0]])
-    const mdnsB = new GoMulticastDNS(peerIds[1], [peerAddrs[1]])
+  it('should emit peer data when peer is discovered', async () => {
+    const mdnsA = new GoMulticastDNS({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
+    const mdnsB = new GoMulticastDNS({
+      peerId: peerIds[1],
+      multiaddrs: [peerAddrs[1]]
+    })
     const defer = pDefer()
 
     mdnsA.on('peer', ({ id, multiaddrs }) => {

--- a/test/compat/querier.spec.js
+++ b/test/compat/querier.spec.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
 const MDNS = require('multicast-dns')
 const OS = require('os')
 const delay = require('delay')
@@ -19,17 +19,13 @@ describe('Querier', () => {
     '/ip4/127.0.0.1/tcp/20001',
     '/ip4/127.0.0.1/tcp/20002'
   ]
-  let peerInfos
+  let peerIds
 
   before(async () => {
-    peerInfos = await Promise.all([
-      PeerInfo.create(),
-      PeerInfo.create()
+    peerIds = await Promise.all([
+      PeerId.create(),
+      PeerId.create()
     ])
-
-    peerInfos.forEach((peer, index) => {
-      peer.multiaddrs.add(peerAddrs[index])
-    })
   })
 
   afterEach(() => {
@@ -40,14 +36,14 @@ describe('Querier', () => {
   })
 
   it('should start and stop', async () => {
-    const querier = new Querier(peerInfos[0].id)
+    const querier = new Querier(peerIds[0])
 
     await querier.start()
     await querier.stop()
   })
 
   it('should query on interval', async () => {
-    querier = new Querier(peerInfos[0].id, { queryPeriod: 0, queryInterval: 10 })
+    querier = new Querier(peerIds[0], { queryPeriod: 0, queryInterval: 10 })
     mdns = MDNS()
 
     let queryCount = 0
@@ -66,7 +62,7 @@ describe('Querier', () => {
 
   it('should not emit peer for responses with non matching service tags', () => {
     return ensureNoPeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
       const bogusServiceTagLocal = '_ifps-discovery._udp'
 
       return [{
@@ -81,7 +77,7 @@ describe('Querier', () => {
 
   it('should not emit peer for responses with missing TXT record', () => {
     return ensureNoPeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -95,7 +91,7 @@ describe('Querier', () => {
 
   it('should not emit peer for responses with missing peer ID in TXT record', () => {
     return ensureNoPeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -115,7 +111,7 @@ describe('Querier', () => {
 
   it('should not emit peer for responses to self', () => {
     return ensureNoPeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -128,7 +124,7 @@ describe('Querier', () => {
         type: 'TXT',
         class: 'IN',
         ttl: 120,
-        data: peerInfos[0].id.toB58String()
+        data: peerIds[0].toB58String()
       }]
     })
   })
@@ -136,7 +132,7 @@ describe('Querier', () => {
   // TODO: unskip when https://github.com/libp2p/js-peer-id/issues/83 is resolved
   it.skip('should not emit peer for responses with invalid peer ID in TXT record', () => {
     return ensureNoPeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -156,7 +152,7 @@ describe('Querier', () => {
 
   it('should not emit peer for responses with missing SRV record', () => {
     return ensureNoPeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -169,14 +165,14 @@ describe('Querier', () => {
         type: 'TXT',
         class: 'IN',
         ttl: 120,
-        data: peerInfos[1].id.toB58String()
+        data: peerIds[1].toB58String()
       }]
     })
   })
 
   it('should emit peer for responses even if no multiaddrs', () => {
     return ensurePeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -189,7 +185,7 @@ describe('Querier', () => {
         type: 'TXT',
         class: 'IN',
         ttl: 120,
-        data: peerInfos[1].id.toB58String()
+        data: peerIds[1].toB58String()
       }, {
         name: peerServiceTagLocal,
         type: 'SRV',
@@ -207,7 +203,7 @@ describe('Querier', () => {
 
   it('should emit peer for responses with valid multiaddrs', () => {
     return ensurePeer(event => {
-      const peerServiceTagLocal = `${peerInfos[1].id.toB58String()}.${SERVICE_TAG_LOCAL}`
+      const peerServiceTagLocal = `${peerIds[1].toB58String()}.${SERVICE_TAG_LOCAL}`
 
       return [{
         name: SERVICE_TAG_LOCAL,
@@ -220,7 +216,7 @@ describe('Querier', () => {
         type: 'TXT',
         class: 'IN',
         ttl: 120,
-        data: peerInfos[1].id.toB58String()
+        data: peerIds[1].toB58String()
       }, {
         name: peerServiceTagLocal,
         type: 'SRV',
@@ -243,11 +239,11 @@ describe('Querier', () => {
   })
 
   /**
-   * Ensure peerInfos[1] are emitted from `querier`
+   * Ensure peerIds[1] are emitted from `querier`
    * @param {Function} getResponse Given a query, construct a response to test the querier
    */
   async function ensurePeer (getResponse) {
-    querier = new Querier(peerInfos[0].id)
+    querier = new Querier(peerIds[0])
     mdns = MDNS()
 
     mdns.on('query', (event, info) => {
@@ -256,17 +252,17 @@ describe('Querier', () => {
       mdns.respond(getResponse(event, info), info)
     })
 
-    let peerInfo
+    let peerId
 
-    querier.on('peer', info => {
+    querier.on('peer', ({ id }) => {
       // Ignore non-test peers
-      if (!info.id.isEqual(peerInfos[1].id)) return
-      peerInfo = info
+      if (!id.isEqual(peerIds[1])) return
+      peerId = id
     })
 
     await querier.start()
     await delay(100)
-    if (!peerInfo) throw new Error('Missing peer')
+    if (!peerId) throw new Error('Missing peer')
   }
 
   /**
@@ -274,7 +270,7 @@ describe('Querier', () => {
    * @param {Function} getResponse Given a query, construct a response to test the querier
    */
   async function ensureNoPeer (getResponse) {
-    querier = new Querier(peerInfos[0].id)
+    querier = new Querier(peerIds[0])
     mdns = MDNS()
 
     mdns.on('query', (event, info) => {
@@ -283,18 +279,18 @@ describe('Querier', () => {
       mdns.respond(getResponse(event, info), info)
     })
 
-    let peerInfo
+    let peerId
 
-    querier.on('peer', info => {
+    querier.on('peer', ({ id }) => {
       // Ignore non-test peers
-      if (!info.id.isEqual(peerInfos[0].id) && !info.id.isEqual(peerInfos[1].id)) return
-      peerInfo = info
+      if (!id.isEqual(peerIds[0]) && !id.isEqual(peerIds[1])) return
+      peerId = id
     })
 
     await querier.start()
     await delay(100)
 
-    if (!peerInfo) return
-    throw Object.assign(new Error('Unexpected peer'), { peerInfo })
+    if (!peerId) return
+    throw Object.assign(new Error('Unexpected peer'), { peerId })
   }
 })

--- a/test/compat/querier.spec.js
+++ b/test/compat/querier.spec.js
@@ -36,14 +36,14 @@ describe('Querier', () => {
   })
 
   it('should start and stop', async () => {
-    const querier = new Querier(peerIds[0])
+    const querier = new Querier({ peerId: peerIds[0] })
 
     await querier.start()
     await querier.stop()
   })
 
   it('should query on interval', async () => {
-    querier = new Querier(peerIds[0], { queryPeriod: 0, queryInterval: 10 })
+    querier = new Querier({ peerId: peerIds[0], queryPeriod: 0, queryInterval: 10 })
     mdns = MDNS()
 
     let queryCount = 0
@@ -243,7 +243,7 @@ describe('Querier', () => {
    * @param {Function} getResponse Given a query, construct a response to test the querier
    */
   async function ensurePeer (getResponse) {
-    querier = new Querier(peerIds[0])
+    querier = new Querier({ peerId: peerIds[0] })
     mdns = MDNS()
 
     mdns.on('query', (event, info) => {
@@ -266,11 +266,11 @@ describe('Querier', () => {
   }
 
   /**
-   * Ensure none of peerInfos are emitted from `querier`
+   * Ensure none of peerIds are emitted from `querier`
    * @param {Function} getResponse Given a query, construct a response to test the querier
    */
   async function ensureNoPeer (getResponse) {
-    querier = new Querier(peerIds[0])
+    querier = new Querier({ peerId: peerIds[0] })
     mdns = MDNS()
 
     mdns.on('query', (event, info) => {

--- a/test/compat/responder.spec.js
+++ b/test/compat/responder.spec.js
@@ -38,7 +38,10 @@ describe('Responder', () => {
   })
 
   it('should start and stop', async () => {
-    const responder = new Responder(peerIds[0], [peerAddrs[0]])
+    const responder = new Responder({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
 
     await responder.start()
     await responder.stop()
@@ -46,7 +49,10 @@ describe('Responder', () => {
 
   it('should not respond to a query if no TCP addresses', async () => {
     const peerId = await PeerId.create()
-    responder = new Responder(peerId, [])
+    responder = new Responder({
+      peerId,
+      multiaddrs: []
+    })
     mdns = MDNS({ multicast: false, interface: '0.0.0.0', port: 0 })
 
     await responder.start()
@@ -72,7 +78,10 @@ describe('Responder', () => {
   })
 
   it('should not respond to a query with non matching service tag', async () => {
-    responder = new Responder(peerIds[0], [peerAddrs[0]])
+    responder = new Responder({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
     mdns = MDNS({ multicast: false, interface: '0.0.0.0', port: 0 })
 
     await responder.start()
@@ -100,7 +109,10 @@ describe('Responder', () => {
   })
 
   it('should respond correctly', async () => {
-    responder = new Responder(peerIds[0], [peerAddrs[0]])
+    responder = new Responder({
+      peerId: peerIds[0],
+      multiaddrs: [peerAddrs[0]]
+    })
     mdns = MDNS({ multicast: false, interface: '0.0.0.0', port: 0 })
 
     await responder.start()

--- a/test/compat/responder.spec.js
+++ b/test/compat/responder.spec.js
@@ -5,7 +5,9 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const PeerInfo = require('peer-info')
+
+const multiaddr = require('multiaddr')
+const PeerId = require('peer-id')
 const MDNS = require('multicast-dns')
 const delay = require('delay')
 const pDefer = require('p-defer')
@@ -16,20 +18,16 @@ const { SERVICE_TAG_LOCAL, MULTICAST_IP, MULTICAST_PORT } = require('../../src/c
 describe('Responder', () => {
   let responder, mdns
   const peerAddrs = [
-    '/ip4/127.0.0.1/tcp/20001',
-    '/ip4/127.0.0.1/tcp/20002'
+    multiaddr('/ip4/127.0.0.1/tcp/20001'),
+    multiaddr('/ip4/127.0.0.1/tcp/20002')
   ]
-  let peerInfos
+  let peerIds
 
   before(async () => {
-    peerInfos = await Promise.all([
-      PeerInfo.create(),
-      PeerInfo.create()
+    peerIds = await Promise.all([
+      PeerId.create(),
+      PeerId.create()
     ])
-
-    peerInfos.forEach((peer, index) => {
-      peer.multiaddrs.add(peerAddrs[index])
-    })
   })
 
   afterEach(() => {
@@ -40,15 +38,15 @@ describe('Responder', () => {
   })
 
   it('should start and stop', async () => {
-    const responder = new Responder(peerInfos[0])
+    const responder = new Responder(peerIds[0], [peerAddrs[0]])
 
     await responder.start()
     await responder.stop()
   })
 
   it('should not respond to a query if no TCP addresses', async () => {
-    const peerInfo = await PeerInfo.create()
-    responder = new Responder(peerInfo)
+    const peerId = await PeerId.create()
+    responder = new Responder(peerId, [])
     mdns = MDNS({ multicast: false, interface: '0.0.0.0', port: 0 })
 
     await responder.start()
@@ -56,7 +54,7 @@ describe('Responder', () => {
     let response
 
     mdns.on('response', event => {
-      if (isResponseFrom(event, peerInfo)) {
+      if (isResponseFrom(event, peerId)) {
         response = event
       }
     })
@@ -74,7 +72,7 @@ describe('Responder', () => {
   })
 
   it('should not respond to a query with non matching service tag', async () => {
-    responder = new Responder(peerInfos[0])
+    responder = new Responder(peerIds[0], [peerAddrs[0]])
     mdns = MDNS({ multicast: false, interface: '0.0.0.0', port: 0 })
 
     await responder.start()
@@ -82,7 +80,7 @@ describe('Responder', () => {
     let response
 
     mdns.on('response', event => {
-      if (isResponseFrom(event, peerInfos[0])) {
+      if (isResponseFrom(event, peerIds[0])) {
         response = event
       }
     })
@@ -102,14 +100,14 @@ describe('Responder', () => {
   })
 
   it('should respond correctly', async () => {
-    responder = new Responder(peerInfos[0])
+    responder = new Responder(peerIds[0], [peerAddrs[0]])
     mdns = MDNS({ multicast: false, interface: '0.0.0.0', port: 0 })
 
     await responder.start()
     const defer = pDefer()
 
     mdns.on('response', event => {
-      if (!isResponseFrom(event, peerInfos[0])) return
+      if (!isResponseFrom(event, peerIds[0])) return
 
       const srvRecord = event.answers.find(a => a.type === 'SRV')
       if (!srvRecord) return defer.reject(new Error('Missing SRV record'))
@@ -121,7 +119,7 @@ describe('Responder', () => {
         .filter(a => ['A', 'AAAA'].includes(a.type))
         .map(a => `/${protos[a.type]}/${a.data}/tcp/${port}`)
 
-      if (!addrs.includes(peerAddrs[0])) {
+      if (!addrs.includes(peerAddrs[0].toString())) {
         return defer.reject(new Error('Missing peer address in response: ' + peerAddrs[0]))
       }
 
@@ -140,7 +138,7 @@ describe('Responder', () => {
   })
 })
 
-function isResponseFrom (res, fromPeerInfo) {
+function isResponseFrom (res, fromPeerId) {
   const answers = res.answers || []
   const ptrRecord = answers.find(a => a.type === 'PTR' && a.name === SERVICE_TAG_LOCAL)
   if (!ptrRecord) return false // Ignore irrelevant
@@ -156,7 +154,7 @@ function isResponseFrom (res, fromPeerInfo) {
   }
 
   // Ignore response from someone else
-  if (fromPeerInfo.id.toB58String() !== peerIdStr) return false
+  if (fromPeerId.toB58String() !== peerIdStr) return false
 
   return true
 }

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -1,23 +1,29 @@
 'use strict'
 
-const test = require('interface-discovery')
+/* eslint-env mocha */
+
+const tests = require('libp2p-interfaces/src/peer-discovery/tests')
+
 const PeerId = require('peer-id')
 const MulticastDNS = require('../src')
 let mdns
 
-const common = {
-  async setup () {
-    const peerId = await PeerId.create()
-    mdns = new MulticastDNS({
-      peerId: peerId,
-      broadcast: false,
-      port: 50001,
-      compat: true
-    })
+describe('compliance tests', () => {
+  tests({
+    async setup () {
+      const peerId = await PeerId.create()
+      mdns = new MulticastDNS({
+        peerId: peerId,
+        broadcast: false,
+        port: 50001,
+        compat: true
+      })
 
-    return mdns
-  }
-}
-
-// use all of the test suits
-test(common)
+      return mdns
+    },
+    async teardown () {
+      // clearInterval(intervalId)
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  })
+})

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -1,15 +1,15 @@
 'use strict'
 
 const test = require('interface-discovery')
-const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
 const MulticastDNS = require('../src')
 let mdns
 
 const common = {
   async setup () {
-    const peerInfo = await PeerInfo.create()
+    const peerId = await PeerId.create()
     mdns = new MulticastDNS({
-      peerInfo,
+      peerId: peerId,
       broadcast: false,
       port: 50001,
       compat: true

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -6,49 +6,59 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const multiaddr = require('multiaddr')
-const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
 
 const MulticastDNS = require('./../src')
 
 describe('MulticastDNS', () => {
-  let pA
-  let pB
-  let pC
-  let pD
+  let pA, aMultiaddrs
+  let pB, bMultiaddrs
+  let pC, cMultiaddrs
+  let pD, dMultiaddrs
 
   before(async function () {
     this.timeout(80 * 1000)
 
     ;[pA, pB, pC, pD] = await Promise.all([
-      PeerInfo.create(),
-      PeerInfo.create(),
-      PeerInfo.create(),
-      PeerInfo.create()
+      PeerId.create(),
+      PeerId.create(),
+      PeerId.create(),
+      PeerId.create()
     ])
 
-    pA.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/20001'))
+    aMultiaddrs = [
+      multiaddr('/ip4/127.0.0.1/tcp/20001')
+    ]
 
-    pB.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/20002'))
-    pB.multiaddrs.add(multiaddr('/ip6/::1/tcp/20002'))
+    bMultiaddrs = [
+      multiaddr('/ip4/127.0.0.1/tcp/20002'),
+      multiaddr('/ip6/::1/tcp/20002')
+    ]
 
-    pC.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/20003'))
-    pC.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/30003/ws'))
+    cMultiaddrs = [
+      multiaddr('/ip4/127.0.0.1/tcp/20003'),
+      multiaddr('/ip4/127.0.0.1/tcp/30003/ws')
+    ]
 
-    pD.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/30003/ws'))
+    dMultiaddrs = [
+      multiaddr('/ip4/127.0.0.1/tcp/30003/ws')
+    ]
   })
 
   it('find another peer', async function () {
     this.timeout(40 * 1000)
 
     const mdnsA = new MulticastDNS({
-      peerInfo: pA,
+      peerId: pA,
+      multiaddrs: aMultiaddrs,
       broadcast: false, // do not talk to ourself
       port: 50001,
       compat: false
     })
 
     const mdnsB = new MulticastDNS({
-      peerInfo: pB,
+      peerId: pB,
+      multiaddrs: bMultiaddrs,
       port: 50001, // port must be the same
       compat: false
     })
@@ -56,9 +66,9 @@ describe('MulticastDNS', () => {
     mdnsA.start()
     mdnsB.start()
 
-    const peerInfo = await new Promise((resolve) => mdnsA.once('peer', resolve))
+    const { id } = await new Promise((resolve) => mdnsA.once('peer', resolve))
 
-    expect(pB.id.toB58String()).to.eql(peerInfo.id.toB58String())
+    expect(pB.toB58String()).to.eql(id.toB58String())
 
     await Promise.all([mdnsA.stop(), mdnsB.stop()])
   })
@@ -67,18 +77,21 @@ describe('MulticastDNS', () => {
     this.timeout(40 * 1000)
 
     const mdnsA = new MulticastDNS({
-      peerInfo: pA,
+      peerId: pA,
+      multiaddrs: aMultiaddrs,
       broadcast: false, // do not talk to ourself
       port: 50003,
       compat: false
     })
     const mdnsC = new MulticastDNS({
-      peerInfo: pC,
+      peerId: pC,
+      multiaddrs: cMultiaddrs,
       port: 50003, // port must be the same
       compat: false
     })
     const mdnsD = new MulticastDNS({
-      peerInfo: pD,
+      peerId: pD,
+      multiaddrs: dMultiaddrs,
       port: 50003, // port must be the same
       compat: false
     })
@@ -87,10 +100,10 @@ describe('MulticastDNS', () => {
     mdnsC.start()
     mdnsD.start()
 
-    const peerInfo = await new Promise((resolve) => mdnsA.once('peer', resolve))
+    const { id, multiaddrs } = await new Promise((resolve) => mdnsA.once('peer', resolve))
 
-    expect(pC.id.toB58String()).to.eql(peerInfo.id.toB58String())
-    expect(peerInfo.multiaddrs.size).to.equal(1)
+    expect(pC.toB58String()).to.eql(id.toB58String())
+    expect(multiaddrs.length).to.equal(1)
 
     await Promise.all([
       mdnsA.stop(),
@@ -103,14 +116,16 @@ describe('MulticastDNS', () => {
     this.timeout(40 * 1000)
 
     const mdnsA = new MulticastDNS({
-      peerInfo: pA,
+      peerId: pA,
+      multiaddrs: aMultiaddrs,
       broadcast: false, // do not talk to ourself
       port: 50001,
       compat: false
     })
 
     const mdnsB = new MulticastDNS({
-      peerInfo: pB,
+      peerId: pB,
+      multiaddrs: bMultiaddrs,
       port: 50001,
       compat: false
     })
@@ -118,10 +133,10 @@ describe('MulticastDNS', () => {
     mdnsA.start()
     mdnsB.start()
 
-    const peerInfo = await new Promise((resolve) => mdnsA.once('peer', resolve))
+    const { id, multiaddrs } = await new Promise((resolve) => mdnsA.once('peer', resolve))
 
-    expect(pB.id.toB58String()).to.eql(peerInfo.id.toB58String())
-    expect(peerInfo.multiaddrs.size).to.equal(2)
+    expect(pB.toB58String()).to.eql(id.toB58String())
+    expect(multiaddrs.length).to.equal(2)
 
     await Promise.all([mdnsA.stop(), mdnsB.stop()])
   })
@@ -130,13 +145,15 @@ describe('MulticastDNS', () => {
     this.timeout(40 * 1000)
 
     const mdnsA = new MulticastDNS({
-      peerInfo: pA,
+      peerId: pA,
+      multiaddrs: aMultiaddrs,
       port: 50004, // port must be the same
       compat: false
     })
 
     const mdnsC = new MulticastDNS({
-      peerInfo: pC,
+      peerId: pC,
+      multiaddrs: cMultiaddrs,
       port: 50004,
       compat: false
     })
@@ -146,7 +163,7 @@ describe('MulticastDNS', () => {
     await mdnsA.stop()
     mdnsC.start()
 
-    mdnsC.once('peer', (peerInfo) => {
+    mdnsC.once('peer', () => {
       throw new Error('Should not receive new peer.')
     })
 
@@ -155,14 +172,22 @@ describe('MulticastDNS', () => {
   })
 
   it('should start and stop with go-libp2p-mdns compat', async () => {
-    const mdns = new MulticastDNS({ peerInfo: pA, port: 50004 })
+    const mdns = new MulticastDNS({
+      peerId: pA,
+      multiaddrs: aMultiaddrs,
+      port: 50004
+    })
 
     await mdns.start()
     await mdns.stop()
   })
 
   it('should not emit undefined peer ids', async () => {
-    const mdns = new MulticastDNS({ peerInfo: pA, port: 50004 })
+    const mdns = new MulticastDNS({
+      peerId: pA,
+      multiaddrs: aMultiaddrs,
+      port: 50004
+    })
     await mdns.start()
 
     return new Promise((resolve, reject) => {

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -191,9 +191,9 @@ describe('MulticastDNS', () => {
     await mdns.start()
 
     return new Promise((resolve, reject) => {
-      mdns.on('peer', (peerInfo) => {
-        if (!peerInfo) {
-          reject(new Error('peerInfo was not set'))
+      mdns.on('peer', (peerData) => {
+        if (!peerData) {
+          reject(new Error('peerData was not set'))
         }
       })
 
@@ -201,7 +201,7 @@ describe('MulticastDNS', () => {
         // query.gotResponse is async - we'll bail from that method when
         // comparing the senders PeerId to our own but it'll happen later
         // so allow enough time for the test to have failed if we emit
-        // empty PeerInfo objects
+        // empty peerData objects
         setTimeout(() => {
           resolve()
         }, 100)


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR changes the `peer-discovery` interface to emit an object containing an `id` property and a `multiaddrs` property.

This adds a multiaddrs property to the constructor for now. This should receive libp2p and access the libp2p listening multiaddrs instead

BREAKING CHANGE: peer event emits an object with id and multiaddr instead of a peer-info

Needs:

- [x] [libp2p/js-libp2p-interfaces#41](https://github.com/libp2p/js-libp2p-interfaces/pull/41)