### PR TITLE
chore: use address manager

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ class MulticastDNS extends EventEmitter {
     this.serviceTag = options.serviceTag || 'ipfs.local'
     this.port = options.port || 5353
     this.peerId = options.peerId
-    this.peerMultiaddrs = options.multiaddrs || []
+    this.peerMultiaddrs = options.libp2p.multiaddrs || []
     this._queryInterval = null
     this._onPeer = this._onPeer.bind(this)
 

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -14,6 +14,9 @@ describe('compliance tests', () => {
       const peerId = await PeerId.create()
       mdns = new MulticastDNS({
         peerId: peerId,
+        libp2p: {
+          multiaddrs: []
+        },
         broadcast: false,
         port: 50001,
         compat: true

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -50,7 +50,9 @@ describe('MulticastDNS', () => {
 
     const mdnsA = new MulticastDNS({
       peerId: pA,
-      multiaddrs: aMultiaddrs,
+      libp2p: {
+        multiaddrs: aMultiaddrs
+      },
       broadcast: false, // do not talk to ourself
       port: 50001,
       compat: false
@@ -58,7 +60,9 @@ describe('MulticastDNS', () => {
 
     const mdnsB = new MulticastDNS({
       peerId: pB,
-      multiaddrs: bMultiaddrs,
+      libp2p: {
+        multiaddrs: bMultiaddrs
+      },
       port: 50001, // port must be the same
       compat: false
     })
@@ -78,20 +82,26 @@ describe('MulticastDNS', () => {
 
     const mdnsA = new MulticastDNS({
       peerId: pA,
-      multiaddrs: aMultiaddrs,
+      libp2p: {
+        multiaddrs: aMultiaddrs
+      },
       broadcast: false, // do not talk to ourself
       port: 50003,
       compat: false
     })
     const mdnsC = new MulticastDNS({
       peerId: pC,
-      multiaddrs: cMultiaddrs,
+      libp2p: {
+        multiaddrs: cMultiaddrs
+      },
       port: 50003, // port must be the same
       compat: false
     })
     const mdnsD = new MulticastDNS({
       peerId: pD,
-      multiaddrs: dMultiaddrs,
+      libp2p: {
+        multiaddrs: dMultiaddrs
+      },
       port: 50003, // port must be the same
       compat: false
     })
@@ -117,7 +127,9 @@ describe('MulticastDNS', () => {
 
     const mdnsA = new MulticastDNS({
       peerId: pA,
-      multiaddrs: aMultiaddrs,
+      libp2p: {
+        multiaddrs: aMultiaddrs
+      },
       broadcast: false, // do not talk to ourself
       port: 50001,
       compat: false
@@ -125,7 +137,9 @@ describe('MulticastDNS', () => {
 
     const mdnsB = new MulticastDNS({
       peerId: pB,
-      multiaddrs: bMultiaddrs,
+      libp2p: {
+        multiaddrs: bMultiaddrs
+      },
       port: 50001,
       compat: false
     })
@@ -146,14 +160,18 @@ describe('MulticastDNS', () => {
 
     const mdnsA = new MulticastDNS({
       peerId: pA,
-      multiaddrs: aMultiaddrs,
+      libp2p: {
+        multiaddrs: aMultiaddrs
+      },
       port: 50004, // port must be the same
       compat: false
     })
 
     const mdnsC = new MulticastDNS({
       peerId: pC,
-      multiaddrs: cMultiaddrs,
+      libp2p: {
+        multiaddrs: cMultiaddrs
+      },
       port: 50004,
       compat: false
     })
@@ -174,7 +192,9 @@ describe('MulticastDNS', () => {
   it('should start and stop with go-libp2p-mdns compat', async () => {
     const mdns = new MulticastDNS({
       peerId: pA,
-      multiaddrs: aMultiaddrs,
+      libp2p: {
+        multiaddrs: aMultiaddrs
+      },
       port: 50004
     })
 
@@ -185,7 +205,9 @@ describe('MulticastDNS', () => {
   it('should not emit undefined peer ids', async () => {
     const mdns = new MulticastDNS({
       peerId: pA,
-      multiaddrs: aMultiaddrs,
+      libp2p: {
+        multiaddrs: aMultiaddrs
+      },
       port: 50004
     })
     await mdns.start()


### PR DESCRIPTION
In the context of the new Address Manager implemented on [libp2p/js-libp2p#612](https://github.com/libp2p/js-libp2p/pull/612), we should get the advertised multiaddrs here.