### PR TITLE
test(fix): wait for the right peer in 3+ peer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "libp2p-interfaces": "^0.3.0",
-    "p-defer": "^3.0.0"
+    "p-defer": "^3.0.0",
+    "p-wait-for": "^3.1.0"
   },
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
This test was flakey for me locally. It uses 3 peers which means it could discover either one of them first. This ensures we're waiting for the actual peer we want to check.