### PR TITLE
fix: actually check tcp multiaddrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mdns",
   "devDependencies": {
-    "aegir": "^21.0.2",
+    "aegir": "^25.0.0",
     "chai": "^4.2.0",
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
@@ -44,9 +44,10 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "multiaddr": "^7.1.0",
+    "mafmt": "^7.1.0",
+    "multiaddr": "^7.5.0",
     "multicast-dns": "^7.2.0",
-    "peer-id": "~0.13.3"
+    "peer-id": "^0.13.13"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "mafmt": "^7.1.0",
     "multiaddr": "^7.5.0",
     "multicast-dns": "^7.2.0",
     "peer-id": "^0.13.13"

--- a/src/compat/responder.js
+++ b/src/compat/responder.js
@@ -23,7 +23,13 @@ class Responder {
   }
 
   _onQuery (event, info) {
-    const addresses = this._multiaddrs.map(ma => ma.toOptions())
+    const addresses = this._multiaddrs.reduce((acc, addr) => {
+      if (addr.isThinWaistAddress()) {
+        acc.push(addr.toOptions())
+      }
+      return acc
+    }, [])
+
     // Only announce TCP for now
     if (!addresses.length) return
 

--- a/src/query.js
+++ b/src/query.js
@@ -86,7 +86,13 @@ module.exports = {
   gotQuery: function (qry, mdns, peerId, multiaddrs, serviceTag, broadcast) {
     if (!broadcast) { return }
 
-    const addresses = multiaddrs.map(ma => ma.toOptions())
+    const addresses = multiaddrs.reduce((acc, addr) => {
+      if (addr.isThinWaistAddress()) {
+        acc.push(addr.toOptions())
+      }
+      return acc
+    }, [])
+
     // Only announce TCP for now
     if (addresses.length === 0) { return }
 

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -28,17 +28,21 @@ describe('MulticastDNS', () => {
     ])
 
     aMultiaddrs = [
-      multiaddr('/ip4/127.0.0.1/tcp/20001')
+      multiaddr('/ip4/127.0.0.1/tcp/20001'),
+      multiaddr('/dns4/webrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star'),
+      multiaddr('/dns4/discovery.libp2p.io/tcp/8443')
     ]
 
     bMultiaddrs = [
       multiaddr('/ip4/127.0.0.1/tcp/20002'),
-      multiaddr('/ip6/::1/tcp/20002')
+      multiaddr('/ip6/::1/tcp/20002'),
+      multiaddr('/dnsaddr/discovery.libp2p.io')
     ]
 
     cMultiaddrs = [
       multiaddr('/ip4/127.0.0.1/tcp/20003'),
-      multiaddr('/ip4/127.0.0.1/tcp/30003/ws')
+      multiaddr('/ip4/127.0.0.1/tcp/30003/ws'),
+      multiaddr('/dns4/discovery.libp2p.io')
     ]
 
     dMultiaddrs = [


### PR DESCRIPTION
`multiaddr.toOptions` can return addresses that are not TCP only multiaddrs. This can cause dns based multiaddrs to be returned, which causes an error because the underlying dns system expects an IP address as an answer.

This change leverages the `multiaddr.isThinWaistAddress()` to avoid responding with invalid addresses.