### PR TITLE
chore: upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "p-wait-for": "^3.1.0"
   },
   "dependencies": {
-    "buffer": "^5.6.0",
     "debug": "^4.1.1",
     "multiaddr": "^8.0.0",
     "multicast-dns": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -35,18 +35,17 @@
   "homepage": "https://github.com/libp2p/js-libp2p-mdns",
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
     "delay": "^4.3.0",
-    "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "^0.3.0",
+    "libp2p-interfaces": "^0.4.0",
     "p-defer": "^3.0.0",
     "p-wait-for": "^3.1.0"
   },
   "dependencies": {
+    "buffer": "^5.6.0",
     "debug": "^4.1.1",
-    "multiaddr": "^7.5.0",
+    "multiaddr": "^8.0.0",
     "multicast-dns": "^7.2.0",
-    "peer-id": "^0.13.13"
+    "peer-id": "^0.14.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/compat/responder.js
+++ b/src/compat/responder.js
@@ -4,6 +4,7 @@ const OS = require('os')
 const MDNS = require('multicast-dns')
 const log = require('debug')('libp2p:mdns:compat:responder')
 const { SERVICE_TAG_LOCAL } = require('./constants')
+const { Buffer } = require('buffer')
 
 class Responder {
   constructor ({ peerId, multiaddrs }) {

--- a/src/compat/responder.js
+++ b/src/compat/responder.js
@@ -4,7 +4,6 @@ const OS = require('os')
 const MDNS = require('multicast-dns')
 const log = require('debug')('libp2p:mdns:compat:responder')
 const { SERVICE_TAG_LOCAL } = require('./constants')
-const { Buffer } = require('buffer')
 
 class Responder {
   constructor ({ peerId, multiaddrs }) {

--- a/test/compat/go-multicast-dns.spec.js
+++ b/test/compat/go-multicast-dns.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('aegir/utils/chai')
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const pDefer = require('p-defer')

--- a/test/compat/querier.spec.js
+++ b/test/compat/querier.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const PeerId = require('peer-id')
 const MDNS = require('multicast-dns')
 const OS = require('os')

--- a/test/compat/responder.spec.js
+++ b/test/compat/responder.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('aegir/utils/chai')
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const MDNS = require('multicast-dns')

--- a/test/multicast-dns.spec.js
+++ b/test/multicast-dns.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const pWaitFor = require('p-wait-for')


### PR DESCRIPTION
BREAKING CHANGES:

- All deps of this module now use Uint8Arrays instead of node Buffers