### PR TITLE
chore: update to new peer-id

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [14, 15]
+        node: [16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mdns",
   "devDependencies": {
-    "aegir": "^33.0.0",
+    "aegir": "^36.0.2",
     "delay": "^5.0.0",
-    "libp2p-interfaces": "^1.0.0",
-    "libp2p-interfaces-compliance-tests": "^1.0.0",
+    "libp2p-interfaces": "^2.0.1",
+    "libp2p-interfaces-compliance-tests": "^2.0.1",
     "p-defer": "^3.0.0",
     "p-wait-for": "^3.1.0"
   },
@@ -42,7 +42,7 @@
     "debug": "^4.3.1",
     "multiaddr": "^10.0.0",
     "multicast-dns": "^7.2.0",
-    "peer-id": "^0.15.0"
+    "peer-id": "^0.16.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
BREAKING CHANGE: requires node 15+