### PR TITLE
[feature/multicast-dns] Added support for custom DNS server IP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export interface MulticastDNSOptions {
   interval?: number
   serviceTag?: string
   port?: number
+  ip?: number
   compat?: boolean
   compatQueryPeriod?: number
   compatQueryInterval?: number
@@ -80,7 +81,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
       return
     }
 
-    this.mdns = multicastDNS({ port: this.port })
+    this.mdns = multicastDNS({ port: this.port, ip: this.ip })
     this.mdns.on('query', this._onMdnsQuery)
     this.mdns.on('response', this._onMdnsResponse)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export interface MulticastDNSOptions {
   interval?: number
   serviceTag?: string
   port?: number
-  ip?: number
+  ip?: string
   compat?: boolean
   compatQueryPeriod?: number
   compatQueryInterval?: number
@@ -28,6 +28,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
   private readonly interval: number
   private readonly serviceTag: string
   private readonly port: number
+  private readonly ip: string
   private _queryInterval: ReturnType<typeof setInterval> | null
   private readonly _goMdns?: GoMulticastDNS
   private components: Components = new Components()

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements P
     this.broadcast = options.broadcast !== false
     this.interval = options.interval ?? (1e3 * 10)
     this.serviceTag = options.serviceTag ?? 'ipfs.local'
+    this.ip = options.ip ?? '224.0.0.251'
     this.port = options.port ?? 5353
     this._queryInterval = null
     this._onPeer = this._onPeer.bind(this)

--- a/test/multicast-dns.spec.ts
+++ b/test/multicast-dns.spec.ts
@@ -225,4 +225,31 @@ describe('MulticastDNS', () => {
 
     await stop(mdnsA)
   })
+
+  it('find another peer with different udp4 address', async function () {
+    this.timeout(40 * 1000)
+
+    const mdnsA = mdns({
+      broadcast: false, // do not talk to ourself
+      port: 50005,
+      ip: '224.0.0.252',
+      compat: false
+    })(getComponents(pA, aMultiaddrs))
+
+    const mdnsB = mdns({
+      port: 50005, // port must be the same
+      ip: '224.0.0.252', // ip must be the same
+      compat: false
+    })(getComponents(pB, bMultiaddrs))
+
+    await start(mdnsA, mdnsB)
+
+    const { detail: { id } } = await new Promise<CustomEvent<PeerInfo>>((resolve) => mdnsA.addEventListener('peer', resolve, {
+      once: true
+    }))
+
+    expect(pB.toString()).to.eql(id.toString())
+
+    await stop(mdnsA, mdnsB)
+  })
 })


### PR DESCRIPTION
I need to test my app for a custom DNS server (that's not the default one), and `multicastdns()` does not supports it.

I've added the `ip` option according to [the multicast-dns dependency](https://github.com/mafintosh/multicast-dns#mdns--multicastdnsoptions).