### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-peer-discovery": "^1.0.1",
     "@libp2p/interface-peer-id": "^1.0.4",
     "@libp2p/interface-peer-info": "^1.0.3",
@@ -144,11 +143,11 @@
     "@multiformats/multiaddr": "^11.0.0",
     "@types/multicast-dns": "^7.2.1",
     "multicast-dns": "^7.2.0",
-    "multiformats": "^9.6.3"
+    "multiformats": "^10.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-address-manager": "^1.0.3",
-    "@libp2p/interface-peer-discovery-compliance-tests": "^1.0.2",
+    "@libp2p/interface-address-manager": "^2.0.0",
+    "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
     "@libp2p/peer-id-factory": "^1.0.18",
     "aegir": "^37.5.3",
     "delay": "^5.0.0",

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -3,27 +3,27 @@ import { EventEmitter, CustomEvent } from '@libp2p/interfaces/events'
 import { Responder } from './responder.js'
 import { Querier } from './querier.js'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface-peer-discovery'
-import type { Components, Initializable } from '@libp2p/components'
 import { symbol } from '@libp2p/interface-peer-discovery'
+import type { MulticastDNSComponents } from '../index.js'
 
 export interface GoMulticastDNSInit {
   queryPeriod?: number
   queryInterval?: number
 }
 
-export class GoMulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery, Initializable {
+export class GoMulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
   private _started: boolean
   private readonly _responder: Responder
   private readonly _querier: Querier
 
-  constructor (options: GoMulticastDNSInit = {}) {
+  constructor (components: MulticastDNSComponents, options: GoMulticastDNSInit = {}) {
     super()
     const { queryPeriod, queryInterval } = options
 
     this._started = false
 
-    this._responder = new Responder()
-    this._querier = new Querier({
+    this._responder = new Responder(components)
+    this._querier = new Querier(components, {
       queryInterval,
       queryPeriod
     })
@@ -39,11 +39,6 @@ export class GoMulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements
 
   get [Symbol.toStringTag] () {
     return '@libp2p/go-mdns'
-  }
-
-  init (components: Components): void {
-    this._responder.init(components)
-    this._querier.init(components)
   }
 
   isStarted () {

--- a/test/compat/go-multicast-dns.spec.ts
+++ b/test/compat/go-multicast-dns.spec.ts
@@ -4,7 +4,6 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import pDefer from 'p-defer'
 import { GoMulticastDNS } from '../../src/compat/index.js'
-import { Components } from '@libp2p/components'
 import { stubInterface } from 'ts-sinon'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
@@ -19,13 +18,12 @@ async function createGoMulticastDNS () {
     multiaddr(`/ip4/127.0.0.1/tcp/${port++}/p2p/${peerId.toString()}`)
   ])
 
-  const components = new Components({
+  const components = {
     peerId,
     addressManager
-  })
+  }
 
-  const mdns = new GoMulticastDNS()
-  mdns.init(components)
+  const mdns = new GoMulticastDNS(components)
 
   return {
     mdns,
@@ -64,7 +62,7 @@ describe('GoMulticastDNS', () => {
     mdnsA.addEventListener('peer', (evt) => {
       const { id } = evt.detail
 
-      if (!componentsB.getPeerId().equals(id)) {
+      if (!componentsB.peerId.equals(id)) {
         return
       }
 
@@ -82,7 +80,7 @@ describe('GoMulticastDNS', () => {
       mdnsB.stop()
     ])
 
-    expect(peerData.id.equals(componentsB.getPeerId())).to.be.true()
-    expect(peerData.multiaddrs.map(ma => ma.toString())).includes(componentsB.getAddressManager().getAddresses()[1].toString())
+    expect(peerData.id.equals(componentsB.peerId)).to.be.true()
+    expect(peerData.multiaddrs.map(ma => ma.toString())).includes(componentsB.addressManager.getAddresses()[1].toString())
   })
 })

--- a/test/compat/querier.spec.ts
+++ b/test/compat/querier.spec.ts
@@ -9,7 +9,6 @@ import { SERVICE_TAG_LOCAL } from '../../src/compat/constants.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { RemoteInfo } from 'dgram'
 import type { Answer } from 'dns-packet'
-import { Components } from '@libp2p/components'
 
 describe('Querier', () => {
   let querier: Querier
@@ -35,16 +34,14 @@ describe('Querier', () => {
   })
 
   it('should start and stop', async () => {
-    querier = new Querier()
-    querier.init(new Components({ peerId: peerIds[0] }))
+    querier = new Querier({ peerId: peerIds[0] })
 
     await querier.start()
     await querier.stop()
   })
 
   it('should query on interval', async () => {
-    querier = new Querier({ queryPeriod: 0, queryInterval: 10 })
-    querier.init(new Components({ peerId: peerIds[0] }))
+    querier = new Querier({ peerId: peerIds[0] }, { queryPeriod: 0, queryInterval: 10 })
 
     mdns = MDNS()
 
@@ -246,8 +243,7 @@ describe('Querier', () => {
    * @param {Function} getResponse - Given a query, construct a response to test the querier
    */
   async function ensurePeer (getResponse: (event: QueryPacket, info: RemoteInfo) => Answer[]) {
-    const querier = new Querier()
-    querier.init(new Components({ peerId: peerIds[0] }))
+    const querier = new Querier({ peerId: peerIds[0] })
     mdns = MDNS()
 
     mdns.on('query', (event, info) => {
@@ -283,8 +279,7 @@ describe('Querier', () => {
    * @param {Function} getResponse - Given a query, construct a response to test the querier
    */
   async function ensureNoPeer (getResponse: (event: QueryPacket, info: RemoteInfo) => Answer[]) {
-    const querier = new Querier()
-    querier.init(new Components({ peerId: peerIds[0] }))
+    const querier = new Querier({ peerId: peerIds[0] })
     mdns = MDNS()
 
     mdns.on('query', (event, info) => {

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -3,13 +3,13 @@
 import tests from '@libp2p/interface-peer-discovery-compliance-tests'
 import { multiaddr } from '@multiformats/multiaddr'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
-import { MulticastDNS } from '../src/index.js'
+import { mdns } from '../src/index.js'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import { CustomEvent } from '@libp2p/interfaces/events'
-import { Components } from '@libp2p/components'
 import { stubInterface } from 'ts-sinon'
+import type { PeerDiscovery } from '@libp2p/interface-peer-discovery'
 
-let mdns: MulticastDNS
+let discovery: PeerDiscovery
 
 describe('compliance tests', () => {
   let intervalId: ReturnType<typeof setInterval>
@@ -24,19 +24,20 @@ describe('compliance tests', () => {
         multiaddr(`/ip4/127.0.0.1/tcp/13921/p2p/${peerId1.toString()}`)
       ])
 
-      mdns = new MulticastDNS({
+      discovery = mdns({
         broadcast: false,
         port: 50001,
         compat: true
-      })
-      mdns.init(new Components({
+      })({
         peerId: peerId1,
         addressManager
-      }))
+      })
 
       // Trigger discovery
       const maStr = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2d'
-      intervalId = setInterval(() => mdns._onPeer(new CustomEvent('peer', {
+
+      // @ts-expect-error not a PeerDiscovery field
+      intervalId = setInterval(() => discovery._onPeer(new CustomEvent('peer', {
         detail: {
           id: peerId2,
           multiaddrs: [multiaddr(maStr)],
@@ -44,7 +45,7 @@ describe('compliance tests', () => {
         }
       })), 1000)
 
-      return mdns
+      return discovery
     },
     async teardown () {
       clearInterval(intervalId)

--- a/test/multicast-dns.spec.ts
+++ b/test/multicast-dns.spec.ts
@@ -5,18 +5,18 @@ import type { Multiaddr } from '@multiformats/multiaddr'
 import { multiaddr } from '@multiformats/multiaddr'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import pWaitFor from 'p-wait-for'
-import { MulticastDNS } from './../src/index.js'
+import { mdns } from './../src/index.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import { stubInterface } from 'ts-sinon'
 import type { AddressManager } from '@libp2p/interface-address-manager'
-import { Components } from '@libp2p/components'
+import { start, stop } from '@libp2p/interfaces/startable'
 
 function getComponents (peerId: PeerId, multiaddrs: Multiaddr[]) {
   const addressManager = stubInterface<AddressManager>()
   addressManager.getAddresses.returns(multiaddrs)
 
-  return new Components({ peerId, addressManager })
+  return { peerId, addressManager }
 }
 
 describe('MulticastDNS', () => {
@@ -65,21 +65,18 @@ describe('MulticastDNS', () => {
   it('find another peer', async function () {
     this.timeout(40 * 1000)
 
-    const mdnsA = new MulticastDNS({
+    const mdnsA = mdns({
       broadcast: false, // do not talk to ourself
       port: 50001,
       compat: false
-    })
-    mdnsA.init(getComponents(pA, aMultiaddrs))
+    })(getComponents(pA, aMultiaddrs))
 
-    const mdnsB = new MulticastDNS({
+    const mdnsB = mdns({
       port: 50001, // port must be the same
       compat: false
-    })
-    mdnsB.init(getComponents(pB, bMultiaddrs))
+    })(getComponents(pB, bMultiaddrs))
 
-    await mdnsA.start()
-    await mdnsB.start()
+    await start(mdnsA, mdnsB)
 
     const { detail: { id } } = await new Promise<CustomEvent<PeerInfo>>((resolve) => mdnsA.addEventListener('peer', resolve, {
       once: true
@@ -87,32 +84,27 @@ describe('MulticastDNS', () => {
 
     expect(pB.toString()).to.eql(id.toString())
 
-    await Promise.all([mdnsA.stop(), mdnsB.stop()])
+    await stop(mdnsA, mdnsB)
   })
 
   it('only announce TCP multiaddrs', async function () {
     this.timeout(40 * 1000)
 
-    const mdnsA = new MulticastDNS({
+    const mdnsA = mdns({
       broadcast: false, // do not talk to ourself
       port: 50003,
       compat: false
-    })
-    mdnsA.init(getComponents(pA, aMultiaddrs))
-    const mdnsC = new MulticastDNS({
+    })(getComponents(pA, aMultiaddrs))
+    const mdnsC = mdns({
       port: 50003, // port must be the same
       compat: false
-    })
-    mdnsC.init(getComponents(pC, cMultiaddrs))
-    const mdnsD = new MulticastDNS({
+    })(getComponents(pC, cMultiaddrs))
+    const mdnsD = mdns({
       port: 50003, // port must be the same
       compat: false
-    })
-    mdnsD.init(getComponents(pD, dMultiaddrs))
+    })(getComponents(pD, dMultiaddrs))
 
-    await mdnsA.start()
-    await mdnsC.start()
-    await mdnsD.start()
+    await start(mdnsA, mdnsC, mdnsD)
 
     const peers = new Map()
     const expectedPeer = pC.toString()
@@ -125,31 +117,24 @@ describe('MulticastDNS', () => {
 
     expect(peers.get(expectedPeer).multiaddrs.length).to.equal(1)
 
-    await Promise.all([
-      mdnsA.stop(),
-      mdnsC.stop(),
-      mdnsD.stop()
-    ])
+    await stop(mdnsA, mdnsC, mdnsD)
   })
 
   it('announces IP6 addresses', async function () {
     this.timeout(40 * 1000)
 
-    const mdnsA = new MulticastDNS({
+    const mdnsA = mdns({
       broadcast: false, // do not talk to ourself
       port: 50001,
       compat: false
-    })
-    mdnsA.init(getComponents(pA, aMultiaddrs))
+    })(getComponents(pA, aMultiaddrs))
 
-    const mdnsB = new MulticastDNS({
+    const mdnsB = mdns({
       port: 50001,
       compat: false
-    })
-    mdnsB.init(getComponents(pB, bMultiaddrs))
+    })(getComponents(pB, bMultiaddrs))
 
-    await mdnsA.start()
-    await mdnsB.start()
+    await start(mdnsA, mdnsB)
 
     const { detail: { id, multiaddrs } } = await new Promise<CustomEvent<PeerInfo>>((resolve) => mdnsA.addEventListener('peer', resolve, {
       once: true
@@ -158,28 +143,26 @@ describe('MulticastDNS', () => {
     expect(pB.toString()).to.eql(id.toString())
     expect(multiaddrs.length).to.equal(2)
 
-    await Promise.all([mdnsA.stop(), mdnsB.stop()])
+    await stop(mdnsA, mdnsB)
   })
 
   it('doesn\'t emit peers after stop', async function () {
     this.timeout(40 * 1000)
 
-    const mdnsA = new MulticastDNS({
+    const mdnsA = mdns({
       port: 50004, // port must be the same
       compat: false
-    })
-    mdnsA.init(getComponents(pA, aMultiaddrs))
+    })(getComponents(pA, aMultiaddrs))
 
-    const mdnsC = new MulticastDNS({
+    const mdnsC = mdns({
       port: 50004,
       compat: false
-    })
-    mdnsC.init(getComponents(pD, dMultiaddrs))
+    })(getComponents(pD, dMultiaddrs))
 
-    await mdnsA.start()
+    await start(mdnsA)
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    await mdnsA.stop()
-    await mdnsC.start()
+    await stop(mdnsA)
+    await start(mdnsC)
 
     mdnsC.addEventListener('peer', () => {
       throw new Error('Should not receive new peer.')
@@ -188,39 +171,39 @@ describe('MulticastDNS', () => {
     })
 
     await new Promise((resolve) => setTimeout(resolve, 5000))
-    await mdnsC.stop()
+    await stop(mdnsC)
   })
 
   it('should start and stop with go-libp2p-mdns compat', async () => {
-    const mdns = new MulticastDNS({
+    const mdnsA = mdns({
       port: 50004
-    })
-    mdns.init(getComponents(pA, aMultiaddrs))
+    })(getComponents(pA, aMultiaddrs))
 
-    await mdns.start()
-    await mdns.stop()
+    await start(mdnsA)
+    await stop(mdnsA)
   })
 
   it('should not emit undefined peer ids', async () => {
-    const mdns = new MulticastDNS({
+    const mdnsA = mdns({
       port: 50004
-    })
-    mdns.init(getComponents(pA, aMultiaddrs))
-    await mdns.start()
+    })(getComponents(pA, aMultiaddrs))
+    await start(mdnsA)
 
     await new Promise<void>((resolve, reject) => {
-      mdns.addEventListener('peer', (evt) => {
+      mdnsA.addEventListener('peer', (evt) => {
         if (evt.detail == null) {
           reject(new Error('peerData was not set'))
         }
       })
 
-      if (mdns.mdns == null) {
+      // @ts-expect-error not a PeerDiscovery field
+      if (mdnsA.mdns == null) {
         reject(new Error('mdns property was not set'))
         return
       }
 
-      mdns.mdns.on('response', () => {
+      // @ts-expect-error not a PeerDiscovery field
+      mdnsA.mdns.on('response', () => {
         // query.gotResponse is async - we'll bail from that method when
         // comparing the senders PeerId to our own but it'll happen later
         // so allow enough time for the test to have failed if we emit
@@ -231,7 +214,8 @@ describe('MulticastDNS', () => {
       })
 
       // this will cause us to respond to ourselves
-      mdns.mdns.query({
+      // @ts-expect-error not a PeerDiscovery field
+      mdnsA.mdns.query({
         questions: [{
           name: 'localhost',
           type: 'A'
@@ -239,6 +223,6 @@ describe('MulticastDNS', () => {
       })
     })
 
-    await mdns.stop()
+    await stop(mdnsA)
   })
 })


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection