### PR TITLE
fix!: update multiformats to v11.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,21 +136,21 @@
   },
   "dependencies": {
     "@libp2p/interface-peer-discovery": "^1.0.1",
-    "@libp2p/interface-peer-id": "^1.0.4",
+    "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-peer-info": "^1.0.3",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
-    "@libp2p/peer-id": "^1.1.15",
+    "@libp2p/peer-id": "^2.0.0",
     "@multiformats/multiaddr": "^11.0.0",
     "@types/multicast-dns": "^7.2.1",
     "multicast-dns": "^7.2.0",
-    "multiformats": "^10.0.0"
+    "multiformats": "^11.0.0"
   },
   "devDependencies": {
     "@libp2p/interface-address-manager": "^2.0.0",
     "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
-    "@libp2p/peer-id-factory": "^1.0.18",
-    "aegir": "^37.5.3",
+    "@libp2p/peer-id-factory": "^2.0.0",
+    "aegir": "^37.9.1",
     "delay": "^5.0.0",
     "p-defer": "^4.0.0",
     "p-wait-for": "^5.0.0",


### PR DESCRIPTION
The CID class in multiformats v11 has breaking changes so update all deps to use the new version.