### PR TITLE
fix: do not append peer id to advertised addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
   },
   "dependencies": {
     "@libp2p/interface-peer-discovery": "^1.0.5",
-    "@libp2p/interface-peer-id": "^2.0.1",
     "@libp2p/interface-peer-info": "^1.0.8",
     "@libp2p/interfaces": "^3.3.1",
     "@libp2p/logger": "^2.0.5",
@@ -149,6 +148,7 @@
   "devDependencies": {
     "@libp2p/interface-address-manager": "^2.0.1",
     "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.1",
+    "@libp2p/interface-peer-id": "^2.0.1",
     "@libp2p/peer-id-factory": "^2.0.0",
     "aegir": "^38.1.2",
     "p-wait-for": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interface-peer-
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import { symbol } from '@libp2p/interface-peer-discovery'
 import { stringGen } from './utils.js'
-import type { PeerId } from '@libp2p/interface-peer-id'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 
 const log = logger('libp2p:mdns')
@@ -21,7 +20,6 @@ export interface MulticastDNSInit {
 }
 
 export interface MulticastDNSComponents {
-  peerId: PeerId
   addressManager: AddressManager
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,12 +92,11 @@ class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDisc
     }
 
     log.trace('received incoming mDNS query')
-    const localPeerId = this.components.peerId
     query.gotQuery(
       event,
       this.mdns,
       this.peerName,
-      this.components.addressManager.getAddresses().map((ma) => ma.encapsulate('/p2p/' + localPeerId.toString())),
+      this.components.addressManager.getAddresses(),
       this.serviceTag,
       this.broadcast)
   }
@@ -109,7 +108,7 @@ class MulticastDNS extends EventEmitter<PeerDiscoveryEvents> implements PeerDisc
       const foundPeer = query.gotResponse(event, this.peerName, this.serviceTag)
 
       if (foundPeer != null) {
-        log('discovered peer in mDNS qeury response %p', foundPeer.id)
+        log('discovered peer in mDNS query response %p', foundPeer.id)
 
         this.dispatchEvent(new CustomEvent<PeerInfo>('peer', {
           detail: foundPeer

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -28,7 +28,6 @@ describe('compliance tests', () => {
         broadcast: false,
         port: 50001
       })({
-        peerId: peerId1,
         addressManager
       })
 

--- a/test/multicast-dns.spec.ts
+++ b/test/multicast-dns.spec.ts
@@ -14,7 +14,7 @@ import { start, stop } from '@libp2p/interfaces/startable'
 
 function getComponents (peerId: PeerId, multiaddrs: Multiaddr[]): { peerId: PeerId, addressManager: StubbedInstance<AddressManager> } {
   const addressManager = stubInterface<AddressManager>()
-  addressManager.getAddresses.returns(multiaddrs)
+  addressManager.getAddresses.returns(multiaddrs.map(ma => ma.encapsulate(`/p2p/${peerId.toString()}`)))
 
   return { peerId, addressManager }
 }

--- a/test/multicast-dns.spec.ts
+++ b/test/multicast-dns.spec.ts
@@ -5,18 +5,18 @@ import type { Multiaddr } from '@multiformats/multiaddr'
 import { multiaddr } from '@multiformats/multiaddr'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import pWaitFor from 'p-wait-for'
-import { mdns } from './../src/index.js'
+import { mdns, MulticastDNSComponents } from './../src/index.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
-import { StubbedInstance, stubInterface } from 'ts-sinon'
+import { stubInterface } from 'ts-sinon'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import { start, stop } from '@libp2p/interfaces/startable'
 
-function getComponents (peerId: PeerId, multiaddrs: Multiaddr[]): { peerId: PeerId, addressManager: StubbedInstance<AddressManager> } {
+function getComponents (peerId: PeerId, multiaddrs: Multiaddr[]): MulticastDNSComponents {
   const addressManager = stubInterface<AddressManager>()
   addressManager.getAddresses.returns(multiaddrs.map(ma => ma.encapsulate(`/p2p/${peerId.toString()}`)))
 
-  return { peerId, addressManager }
+  return { addressManager }
 }
 
 describe('MulticastDNS', () => {


### PR DESCRIPTION
The libp2p address manager does this so we can just treat the addresses as opaque values here.

Fixes https://github.com/libp2p/js-libp2p/issues/1673